### PR TITLE
Fix SMS Segment Ordering Issue in smsdb_put

### DIFF
--- a/src/smsdb.c
+++ b/src/smsdb.c
@@ -375,7 +375,7 @@ int smsdb_put(const char* id, const char* addr, int ref, int parts, int order, c
         res = sqlite3_column_int(get_incomingmsg_cnt, 0);
     }
 
-    if (res > 0 && order == parts) {
+    if (res == parts) {
         {
             SCOPED_STMT(get_incomingmsg);
             if (bind_ast_str(get_incomingmsg, 1, fullkey) != SQLITE_OK) {


### PR DESCRIPTION
Related issue: https://github.com/RoEdAl/asterisk-chan-quectel/issues/11#issuecomment-1923205774

The condition check in the smsdb_put function now ensures all segments are received before processing. （when order == parts, (e.g. the quectel receive the msg parts in the order of 1, 3, 2, after received the third msg, the `res > 0 && order == parts` conditions will be satisfied, however part 2 of the msg still not received.

This commit may fixes the issue where the segments were received out of order and the message was not being reassembled correctly.